### PR TITLE
Branch 25 4 20

### DIFF
--- a/R/classify_occ.R
+++ b/R/classify_occ.R
@@ -134,15 +134,15 @@ classify_occ <- function(occ,
     }
     if(crit.levels[i] == "det_by_spec"){
 
-      DSpec <- which(r.occ$vec.crit %in% "f")
-
 
       if(!is.null(spec)){
         DSpec <- unlist(lapply(1:nrow(spec.list),
                                function(x) func.det.by.esp(r.occ, x, spec.list)))
 
-        naturaList_levels[DSpec] <- apply(r.occ[DSpec,], 1,
-                                          function(x) specialist.conference(x, spec.list))
+        if(length(DSpec) > 0){
+          naturaList_levels[DSpec] <- apply(r.occ[DSpec,], 1,
+                                            function(x) specialist.conference(x, spec.list))
+        }
       }
     }
   } # end of classification

--- a/R/map_module.R
+++ b/R/map_module.R
@@ -305,7 +305,9 @@ map_module <- function(occ.cl,
       observeEvent(input$map_draw_all_features, {
 
 
-        if(length(input$map_draw_all_features$features) == 0){return()}
+        if(length(input$map_draw_all_features$features) == 0){
+          values$list.pol.df <- list()
+        }
         if(length(input$map_draw_all_features$features) >0){
           for(i in 1:length(input$map_draw_all_features$features)){
             values$list.pol.df[[i]] <- pol.coords(input$map_draw_all_features$features[[i]])


### PR DESCRIPTION
Errors fixed:

1. When a polygon selection in map_module is deleted the points that were inside them remains selected.

2. In classify_occ, when a specialist dataframe is provided with just one line, or when none of the specilists in the list are in the occ dataset, the function stop.

